### PR TITLE
Osm landfill mine quarry

### DIFF
--- a/dist/LeafletEnvironmentalLayers.js
+++ b/dist/LeafletEnvironmentalLayers.js
@@ -28597,7 +28597,7 @@ L.LayerGroup.OSMLandfillMineQuarryLayer = L.LayerGroup.extend(
                 content += "<strong>" + key + ": </strong>" + val + "<br>";
             });
             content += "<hr>The data included in this layer is from www.openstreetmap.org. The data is made available under ODbL.<br>";
-            content += "From the <a href=#>OSM LMQ Inventory</a> (<a href = https://publiclab.org/notes/sagarpreet/06-06-2018/leaflet-environmental-layer-library?_=1528283515>info</a>).";
+            content += "From the <a href=https://github.com/publiclab/leaflet-environmental-layers/pull/94>OSM LMQ Inventory</a> (<a href = https://publiclab.org/notes/sagarpreet/06-06-2018/leaflet-environmental-layer-library?_=1528283515>info</a>).";
             return content;
         },
 

--- a/dist/LeafletEnvironmentalLayers.js
+++ b/dist/LeafletEnvironmentalLayers.js
@@ -26647,8 +26647,8 @@ require('./indigenousLandsTerritoriesLayer.js');
 require('./indigenousLandsLanguagesLayer.js');
 require('./indigenousLandsTreatiesLayer.js') ;
 require('./aqicnLayer.js');
-
-},{"./aqicnLayer.js":8,"./fractracker.js":9,"./indigenousLandsLanguagesLayer.js":10,"./indigenousLandsTerritoriesLayer.js":11,"./indigenousLandsTreatiesLayer.js":12,"./mapKnitterLayer.js":14,"./odorReportLayer.js":15,"./openWeatherMapLayer.js":16,"./purpleAirMarkerLayer.js":17,"./purpleLayer.js":18,"./skyTruthLayer.js":19,"./toxicReleaseLayer.js":20,"jquery":2,"leaflet":6,"leaflet-providers":5}],14:[function(require,module,exports){
+require('./osmLandfillMineQuarryLayer.js');
+},{"./aqicnLayer.js":8,"./fractracker.js":9,"./indigenousLandsLanguagesLayer.js":10,"./indigenousLandsTerritoriesLayer.js":11,"./indigenousLandsTreatiesLayer.js":12,"./mapKnitterLayer.js":14,"./odorReportLayer.js":15,"./openWeatherMapLayer.js":16,"./osmLandfillMineQuarryLayer.js":17,"./purpleAirMarkerLayer.js":18,"./purpleLayer.js":19,"./skyTruthLayer.js":20,"./toxicReleaseLayer.js":21,"jquery":2,"leaflet":6,"leaflet-providers":5}],14:[function(require,module,exports){
  L.Icon.MapKnitterIcon = L.Icon.extend({
     options: {
       iconUrl: 'https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-red.png',
@@ -28485,6 +28485,186 @@ L.OWM.Utils = {
 
 
 },{}],17:[function(require,module,exports){
+L.LayerGroup.OSMLandfillMineQuarryLayer = L.LayerGroup.extend(
+
+    {
+        options: {
+            url: 'www.overpass-api.de/api/xapi?*[landuse=landfill][bbox=-119.89105224609376,34.1379517234964,-117.34634399414064,34.76192255039478]',
+            clearOutsideBounds: false,
+            minZoom: 7
+        },
+
+        initialize: function(options) {
+            options = options || {};
+            L.Util.setOptions(this, options);
+            this._layers = {};
+            this._nodes = {}; //Used to store position data for each node
+            this._colorOptions = {
+                landfill: "red",
+                mine: "blue",
+                quarry: "green"
+            }; //Colors for each of the 3 usage types
+        },
+
+        onAdd: function(map) {
+            map.on('moveend', this.requestData, this);
+            this._map = map;
+            this.requestData();
+
+        },
+
+        onRemove: function(map) {
+            map.off('moveend', this.requestData, this);
+            map.spin(false);
+            this.clearLayers();
+            this._layers = {};
+        },
+
+        requestData: function() {
+            var self = this;
+            (function() {
+                var script = document.createElement("SCRIPT");
+                script.src = 'https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js';
+                script.type = 'text/javascript';
+                var northeast = self._map.getBounds().getNorthEast(),
+                    southwest = self._map.getBounds().getSouthWest();
+
+                script.onload = function() {
+                    var $ = window.jQuery;
+                    var countLayers = 0;
+                    for (var key in self._colorOptions) {
+                        //Generate URL for each type
+                        var LMQ_url = "http://www.overpass-api.de/api/xapi?*[landuse=" + key + "][bbox=" + (southwest.lng) + "," + (southwest.lat) + "," + (northeast.lng) + "," + (northeast.lat) + "]";
+                        self._map.spin(true);
+                        $.ajax({
+                            url: LMQ_url,
+                            dataType: "xml",
+                            success: function(data) {
+                                self.parseData(data);
+                                self._map.spin(false);
+                            }
+                        });
+                        /* The structure of the document is as follows:
+                            <node id="node_id", lat="", lon="">
+                            . Rest of nodes here
+                            .
+                            <way id="">
+                                <nd ref="node_id">
+                                . Rest of nodes here, with the node_id defined beforehand
+                                .
+                                <tag k="key", v="value">
+                                . Each object has different keys so it is hard to create a uniform popup
+                                .
+                            .. More ways
+                        */
+                    }
+                };
+                document.getElementsByTagName("head")[0].appendChild(script);
+            })();
+
+
+        },
+
+        getPolygon: function(selector) {
+            var latlngs = [];
+            var self = this;
+            
+            var id = $(selector).attr('id');
+            $(selector).find('nd').each(function() {
+                if (self._nodes[$(this).attr('ref')]) { //Find the coordinates based on the node id
+                    var coords = self._nodes[$(this).attr('ref')];
+                    latlngs.push([coords.lat, coords.lng]); //Add node coordinates
+                } else {
+                    console.log("ERROR: COULDN'T FIND THE NODE ID");
+                }
+            });
+            var LSMPoly;
+            LSMPoly = L.polygon(latlngs, {
+                color: self._colorOptions[$(selector).find('tag[k="landuse"]').attr('v')] //Selects color based on the value for the landuse key
+            }).bindPopup(self.getPopupContent(selector));
+
+            return LSMPoly;
+        },
+
+        getPopupContent: function(selector) {
+            var content = '';
+            //Add each key value pair found
+            $(selector).find('tag').each(function() {
+                var key = $(this).attr('k');
+                var val = $(this).attr('v');
+                if (key === 'landuse') val = val.charAt(0).toUpperCase() + val.slice(1); //Capitalize first letter of the landuse
+                key = key.charAt(0).toUpperCase() + key.slice(1); //Capitalize first letter
+                content += "<strong>" + key + ": </strong>" + val + "<br>";
+            });
+            content += "<hr>The data included in this layer is from www.openstreetmap.org. The data is made available under ODbL.<br>";
+            content += "From the <a href=#>OSM LMQ Inventory</a> (<a href = https://publiclab.org/notes/sagarpreet/06-06-2018/leaflet-environmental-layer-library?_=1528283515>info</a>).";
+            return content;
+        },
+
+        addPolygon: function(selector) {
+            var key = $(selector).attr('id'); //Use the id for the way as the key
+            if (!this._layers[key]) {
+                var poly = this.getPolygon(selector, key);
+                this._layers[key] = poly;
+                this.addLayer(poly);
+            } 
+        },
+
+        parseData: function(data) {
+            var self = this;
+
+            (function() {
+                //Create the map of nodes
+                $(data).find('node').each(function() {
+                    var id = $(this).attr('id'); //Use id as the key
+                    var nodeLat = $(this).attr('lat');
+                    var nodeLng = $(this).attr('lon');
+
+                    if (!self._nodes[id]) {
+                        self._nodes[id] = { //Set value as lat, lng pair provided key doesn't exist
+                            lat: nodeLat,
+                            lng: nodeLng
+                        };
+                    }
+
+                });
+            })();
+
+            (function() {
+                $(data).find('way').each(function() { //Add for each way
+                    self.addPolygon(this);
+                })
+            })();
+            
+            if (this.options.clearOutsideBounds) {
+               this.clearOutsideBounds();
+            }
+        },
+
+        clearOutsideBounds: function() {
+            var bounds = this._map.getBounds(),
+                polyBounds,
+                key;
+
+            for (key in this._layers) {
+                if (this._layers.hasOwnProperty(key)) {
+                    polyBounds = this._layers[key].getBounds();
+
+                    if (!bounds.intersects(polyBounds)) {
+                        this.removeLayer(this._layers[key]);
+                        delete this._layers[key];
+                    }
+                }
+            }
+        }
+    }
+);
+
+
+L.layerGroup.osmLandfillMineQuarryLayer = function(options) {
+    return new L.LayerGroup.OSMLandfillMineQuarryLayer(options);
+};
+},{}],18:[function(require,module,exports){
 require('jquery') ;
 require('leaflet') ;
 
@@ -28594,7 +28774,7 @@ L.layerGroup.purpleAirMarkerLayer = function (options) {
     return new L.LayerGroup.PurpleAirMarkerLayer(options) ;
 };
 
-},{"jquery":2,"leaflet":6}],18:[function(require,module,exports){
+},{"jquery":2,"leaflet":6}],19:[function(require,module,exports){
 require('heatmap.js') ;
 require('leaflet-heatmap') ;
 
@@ -28718,7 +28898,7 @@ L.layerGroup.purpleLayer = function (options) {
     return new L.LayerGroup.PurpleLayer(options) ;
 };
 
-},{"heatmap.js":1,"leaflet-heatmap":4}],19:[function(require,module,exports){
+},{"heatmap.js":1,"leaflet-heatmap":4}],20:[function(require,module,exports){
 L.Icon.SkyTruthIcon = L.Icon.extend({
   options: {
     iconUrl: 'https://www.clker.com/cliparts/T/G/b/7/r/A/red-dot.svg',
@@ -28825,7 +29005,7 @@ L.layerGroup.skyTruthLayer = function (options) {
   return new L.LayerGroup.SkyTruthLayer(options);
 };
 
-},{}],20:[function(require,module,exports){
+},{}],21:[function(require,module,exports){
 L.Icon.ToxicReleaseIcon = L.Icon.extend({
     options: {
       iconUrl: 'https://www.clker.com/cliparts/r/M/L/o/R/i/green-dot.svg',

--- a/example/index.html
+++ b/example/index.html
@@ -245,7 +245,8 @@
        "Territories": IndigenousLandsTerritories,
        "Languages": IndigenousLandsLanguages,
        "Treaties": IndigenousLandsTreaties,
-       "AQI": AQICNLayer} ;
+       "AQI": AQICNLayer,
+       "LSM": OSMLandfillMineQuarryLayer} ;
     var hash = new L.Hash(map, allMapLayers);
     L.control.layers(baseMaps,overlayMaps).addTo(map);
 

--- a/example/index.html
+++ b/example/index.html
@@ -111,7 +111,8 @@
 	  var IndigenousLandsLanguages = L.layerGroup.indigenousLandsLanguagesLayer();
     var IndigenousLandsTreaties = L.layerGroup.indigenousLandsTreatiesLayer();
 
-
+    var OSMLandfillMineQuarryLayer = L.layerGroup.osmLandfillMineQuarryLayer();
+    
      var Wisconsin_NM  = L.esri.featureLayer({
        url: 'https://services.arcgis.com/jDGuO8tYggdCCnUJ/arcgis/rest/services/Nonmetallic_and_Potential_frac_sand_mine_proposals_in_West_Central_Wisconsin/FeatureServer/0/',
        simplifyFactor: 1
@@ -197,7 +198,8 @@
          "<span style='color: black'><strong>Indigenous Lands Territories</strong></span>": IndigenousLandsTerritories,
          "<span style='color: black'><strong>Indigenous Lands Languages</strong></span>": IndigenousLandsLanguages,
          "<span style='color: black'><strong>Indigenous Lands Treaties</strong></span>": IndigenousLandsTreaties,
-         "<span style='color: black'><strong>Air Quality Index</strong></span>": AQICNLayer
+         "<span style='color: black'><strong>Air Quality Index</strong></span>": AQICNLayer,
+         "<strong>OSM <span style='color: red'>Landfills</span>, <span style='color: blue'>Mines</span>, <span style='color: green'>Quarries</span></strong>": OSMLandfillMineQuarryLayer
 
     };
     var allMapLayers = {"BL1": baselayer1 ,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-environmental-layers",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "index.js",
   "directories": {

--- a/src/leafletEnvironmentalLayers.js
+++ b/src/leafletEnvironmentalLayers.js
@@ -14,3 +14,4 @@ require('./indigenousLandsTerritoriesLayer.js');
 require('./indigenousLandsLanguagesLayer.js');
 require('./indigenousLandsTreatiesLayer.js') ;
 require('./aqicnLayer.js');
+require('./osmLandfillMineQuarryLayer.js');

--- a/src/osmLandfillMineQuarryLayer.js
+++ b/src/osmLandfillMineQuarryLayer.js
@@ -1,0 +1,179 @@
+L.LayerGroup.OSMLandfillMineQuarryLayer = L.LayerGroup.extend(
+
+    {
+        options: {
+            url: 'www.overpass-api.de/api/xapi?*[landuse=landfill][bbox=-119.89105224609376,34.1379517234964,-117.34634399414064,34.76192255039478]',
+            clearOutsideBounds: false,
+            minZoom: 7
+        },
+
+        initialize: function(options) {
+            options = options || {};
+            L.Util.setOptions(this, options);
+            this._layers = {};
+            this._nodes = {}; //Used to store position data for each node
+            this._colorOptions = {
+                landfill: "red",
+                mine: "blue",
+                quarry: "green"
+            }; //Colors for each of the 3 usage types
+        },
+
+        onAdd: function(map) {
+            map.on('moveend', this.requestData, this);
+            this._map = map;
+            this.requestData();
+
+        },
+
+        onRemove: function(map) {
+            map.off('moveend', this.requestData, this);
+            map.spin(false);
+            this.clearLayers();
+            this._layers = {};
+        },
+
+        requestData: function() {
+            var self = this;
+            (function() {
+                var script = document.createElement("SCRIPT");
+                script.src = 'https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js';
+                script.type = 'text/javascript';
+                var northeast = self._map.getBounds().getNorthEast(),
+                    southwest = self._map.getBounds().getSouthWest();
+
+                script.onload = function() {
+                    var $ = window.jQuery;
+                    var countLayers = 0;
+                    for (var key in self._colorOptions) {
+                        //Generate URL for each type
+                        var LMQ_url = "http://www.overpass-api.de/api/xapi?*[landuse=" + key + "][bbox=" + (southwest.lng) + "," + (southwest.lat) + "," + (northeast.lng) + "," + (northeast.lat) + "]";
+                        self._map.spin(true);
+                        $.ajax({
+                            url: LMQ_url,
+                            dataType: "xml",
+                            success: function(data) {
+                                self.parseData(data);
+                                self._map.spin(false);
+                            }
+                        });
+                        /* The structure of the document is as follows:
+                            <node id="node_id", lat="", lon="">
+                            . Rest of nodes here
+                            .
+                            <way id="">
+                                <nd ref="node_id">
+                                . Rest of nodes here, with the node_id defined beforehand
+                                .
+                                <tag k="key", v="value">
+                                . Each object has different keys so it is hard to create a uniform popup
+                                .
+                            .. More ways
+                        */
+                    }
+                };
+                document.getElementsByTagName("head")[0].appendChild(script);
+            })();
+
+
+        },
+
+        getPolygon: function(selector) {
+            var latlngs = [];
+            var self = this;
+            
+            var id = $(selector).attr('id');
+            $(selector).find('nd').each(function() {
+                if (self._nodes[$(this).attr('ref')]) { //Find the coordinates based on the node id
+                    var coords = self._nodes[$(this).attr('ref')];
+                    latlngs.push([coords.lat, coords.lng]); //Add node coordinates
+                } else {
+                    console.log("ERROR: COULDN'T FIND THE NODE ID");
+                }
+            });
+            var LSMPoly;
+            LSMPoly = L.polygon(latlngs, {
+                color: self._colorOptions[$(selector).find('tag[k="landuse"]').attr('v')] //Selects color based on the value for the landuse key
+            }).bindPopup(self.getPopupContent(selector));
+
+            return LSMPoly;
+        },
+
+        getPopupContent: function(selector) {
+            var content = '';
+            //Add each key value pair found
+            $(selector).find('tag').each(function() {
+                var key = $(this).attr('k');
+                var val = $(this).attr('v');
+                if (key === 'landuse') val = val.charAt(0).toUpperCase() + val.slice(1); //Capitalize first letter of the landuse
+                key = key.charAt(0).toUpperCase() + key.slice(1); //Capitalize first letter
+                content += "<strong>" + key + ": </strong>" + val + "<br>";
+            });
+            content += "<hr>The data included in this layer is from www.openstreetmap.org. The data is made available under ODbL.<br>";
+            content += "From the <a href=#>OSM LMQ Inventory</a> (<a href = https://publiclab.org/notes/sagarpreet/06-06-2018/leaflet-environmental-layer-library?_=1528283515>info</a>).";
+            return content;
+        },
+
+        addPolygon: function(selector) {
+            var key = $(selector).attr('id'); //Use the id for the way as the key
+            if (!this._layers[key]) {
+                var poly = this.getPolygon(selector, key);
+                this._layers[key] = poly;
+                this.addLayer(poly);
+            } 
+        },
+
+        parseData: function(data) {
+            var self = this;
+
+            (function() {
+                //Create the map of nodes
+                $(data).find('node').each(function() {
+                    var id = $(this).attr('id'); //Use id as the key
+                    var nodeLat = $(this).attr('lat');
+                    var nodeLng = $(this).attr('lon');
+
+                    if (!self._nodes[id]) {
+                        self._nodes[id] = { //Set value as lat, lng pair provided key doesn't exist
+                            lat: nodeLat,
+                            lng: nodeLng
+                        };
+                    }
+
+                });
+            })();
+
+            (function() {
+                $(data).find('way').each(function() { //Add for each way
+                    self.addPolygon(this);
+                })
+            })();
+            
+            if (this.options.clearOutsideBounds) {
+               this.clearOutsideBounds();
+            }
+        },
+
+        clearOutsideBounds: function() {
+            var bounds = this._map.getBounds(),
+                polyBounds,
+                key;
+
+            for (key in this._layers) {
+                if (this._layers.hasOwnProperty(key)) {
+                    polyBounds = this._layers[key].getBounds();
+
+                    if (!bounds.intersects(polyBounds)) {
+                        this.removeLayer(this._layers[key]);
+                        delete this._layers[key];
+                    }
+                }
+            }
+        }
+    }
+);
+
+
+L.layerGroup.osmLandfillMineQuarryLayer = function(options) {
+    return new L.LayerGroup.OSMLandfillMineQuarryLayer(options);
+};

--- a/src/osmLandfillMineQuarryLayer.js
+++ b/src/osmLandfillMineQuarryLayer.js
@@ -110,7 +110,7 @@ L.LayerGroup.OSMLandfillMineQuarryLayer = L.LayerGroup.extend(
                 content += "<strong>" + key + ": </strong>" + val + "<br>";
             });
             content += "<hr>The data included in this layer is from www.openstreetmap.org. The data is made available under ODbL.<br>";
-            content += "From the <a href=#>OSM LMQ Inventory</a> (<a href = https://publiclab.org/notes/sagarpreet/06-06-2018/leaflet-environmental-layer-library?_=1528283515>info</a>).";
+            content += "From the <a href=https://github.com/publiclab/leaflet-environmental-layers/pull/94>OSM LMQ Inventory</a> (<a href = https://publiclab.org/notes/sagarpreet/06-06-2018/leaflet-environmental-layer-library?_=1528283515>info</a>).";
             return content;
         },
 


### PR DESCRIPTION
Fixes #56 
 
I have added a layer for landfills, mines, and quarries through OSM:
![osmlandsminesquarriescoloredfast](https://user-images.githubusercontent.com/44309027/49352377-3c6e3300-f67d-11e8-8161-82478708af88.gif)


Currently the colors are:
Red for Landfills,
Blue for Mines,
Green for Quarries

As I stated [here](https://github.com/publiclab/leaflet-environmental-layers/issues/56#issuecomment-443552850), I decided to parse the XML instead as the JSON output didn't provided the longitude latitude coordinates.

Currently the map is very slow, as you can see from the gif. It is possible I may have been above the quota. I am not too sure.

I have set the minimum zoom to 7 and clearOutsideBounds to false for now.

Please let me know if you would like me to change anything.

Also, thank you @sagarpreet-chadha . The spinner is super helpful when testing.

Thank you,
Kevin Luo