### PR TITLE
display links in anchor tag in popup of osmLandfillMineQuarryLayer

### DIFF
--- a/dist/LeafletEnvironmentalLayers.js
+++ b/dist/LeafletEnvironmentalLayers.js
@@ -28660,19 +28660,25 @@ L.LayerGroup.OSMLandfillMineQuarryLayer = L.LayerGroup.extend(
         },
 
         getPopupContent: function(selector) {
-            var content = '';
-            //Add each key value pair found
-            $(selector).find('tag').each(function() {
-                var key = $(this).attr('k');
-                var val = $(this).attr('v');
-                if (key === 'landuse') val = val.charAt(0).toUpperCase() + val.slice(1); //Capitalize first letter of the landuse
-                key = key.charAt(0).toUpperCase() + key.slice(1); //Capitalize first letter
-                content += "<strong>" + key + ": </strong>" + val + "<br>";
-            });
-            content += "<hr>The data included in this layer is from www.openstreetmap.org. The data is made available under ODbL.<br>";
-            content += "From the <a href=https://github.com/publiclab/leaflet-environmental-layers/pull/94>OSM LMQ Inventory</a> (<a href = https://publiclab.org/notes/sagarpreet/06-06-2018/leaflet-environmental-layer-library?_=1528283515>info</a>).";
-            return content;
-        },
+					var content = '';
+					//Add each key value pair found
+					$(selector).find('tag').each(function() {
+							var key = $(this).attr('k');
+							var val = $(this).attr('v');
+							if (key === 'landuse') val = val.charAt(0).toUpperCase() + val.slice(1); //Capitalize first letter of the landuse
+							key = key.charAt(0).toUpperCase() + key.slice(1); //Capitalize first letter
+							//Check if the value is a link
+							if (/^((http|https|ftp):\/\/)/.test(val)) {
+								content += "<strong>" + key + ": </strong><a href='" + val + "' target='_blank'>" + val + "</a><br>";
+							}
+							else {
+								content += "<strong>" + key + ": </strong>" + val + "<br>";
+							}
+					});
+					content += "<hr>The data included in this layer is from www.openstreetmap.org. The data is made available under ODbL.<br>";
+					content += "From the <a href=https://github.com/publiclab/leaflet-environmental-layers/pull/94>OSM LMQ Inventory</a> (<a href = https://publiclab.org/notes/sagarpreet/06-06-2018/leaflet-environmental-layer-library?_=1528283515>info</a>).";
+					return content;
+			},
 
         addPolygon: function(selector) {
             var key = $(selector).attr('id'); //Use the id for the way as the key

--- a/src/osmLandfillMineQuarryLayer.js
+++ b/src/osmLandfillMineQuarryLayer.js
@@ -113,7 +113,13 @@ L.LayerGroup.OSMLandfillMineQuarryLayer = L.LayerGroup.extend(
                 var val = $(this).attr('v');
                 if (key === 'landuse') val = val.charAt(0).toUpperCase() + val.slice(1); //Capitalize first letter of the landuse
                 key = key.charAt(0).toUpperCase() + key.slice(1); //Capitalize first letter
-                content += "<strong>" + key + ": </strong>" + val + "<br>";
+                //Check if the value is a link
+                if (/^((http|https|ftp):\/\/)/.test(val)) {
+                    content += "<strong>" + key + ": </strong><a href='" + val + "' target='_blank'>" + val + "</a><br>";
+                }
+                else {
+                    content += "<strong>" + key + ": </strong>" + val + "<br>";
+                }
             });
             content += "<hr>The data included in this layer is from www.openstreetmap.org. The data is made available under ODbL.<br>";
             content += "From the <a href=https://github.com/publiclab/leaflet-environmental-layers/pull/94>OSM LMQ Inventory</a> (<a href = https://publiclab.org/notes/sagarpreet/06-06-2018/leaflet-environmental-layer-library?_=1528283515>info</a>).";


### PR DESCRIPTION
The popup in osmLandfillMineQuarryLayer earlier displayed links as simple text. Changes have been made to display links using anchor tags.

fixes #42 

![image](https://user-images.githubusercontent.com/23582438/53685421-73b5b400-3d40-11e9-9322-1d4fb0af232d.png)
