### PR TITLE
update tile used by open infrastructure maps

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -96,19 +96,19 @@
     var MapKnitter = L.layerGroup.mapKnitterLayer() ;
     var ToxicRelease = L.layerGroup.toxicReleaseLayer() ;
 
-    var OpenInfraMap_Power = L.tileLayer('https://tiles-{s}.openinframap.org/power/{z}/{x}/{y}.png',{
+    var OpenInfraMap_Power = L.tileLayer('https://openinframap.org/tiles/{z}/{x}/{y}.pbf',{
         maxZoom: 18,
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://www.openinframap.org/about.html">About OpenInfraMap</a>'
     });
-    var OpenInfraMap_Petroleum = L.tileLayer('https://tiles-{s}.openinframap.org/petroleum/{z}/{x}/{y}.png', {
+    var OpenInfraMap_Petroleum = L.tileLayer('https://openinframap.org/tiles/{z}/{x}/{y}.pbf', {
       maxZoom: 18,
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://www.openinframap.org/about.html">About OpenInfraMap</a>'
     });
-    var OpenInfraMap_Telecom = L.tileLayer('https://tiles-{s}.openinframap.org/telecoms/{z}/{x}/{y}.png', {
+    var OpenInfraMap_Telecom = L.tileLayer('https://openinframap.org/tiles/{z}/{x}/{y}.pbf', {
       maxZoom: 18,
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://www.openinframap.org/about.html">About OpenInfraMap</a>'
     });
-    var OpenInfraMap_Water = L.tileLayer('https://tiles-{s}.openinframap.org/water/{z}/{x}/{y}.png',{
+    var OpenInfraMap_Water = L.tileLayer('https://openinframap.org/tiles/{z}/{x}/{y}.pbf',{
       maxZoom: 18,
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://www.openinframap.org/about.html">About OpenInfraMap</a>'
     });


### PR DESCRIPTION
The openinframaps have switched to vector tiles and the old raster tiles have been deprecated. The tile had to be updated based on [openinframap.org/map.json](openinframap.org/map.json)

Changing the tile works fine. :)

![openinframap2](https://user-images.githubusercontent.com/23582438/54736031-299d5100-4bcf-11e9-9c7e-ceee528c4a37.gif)

fixes #147