### PR TITLE
Make no longer operating sites appear differently

### DIFF
--- a/src/unearthing.js
+++ b/src/unearthing.js
@@ -39,8 +39,17 @@ L.LayerGroup.unearthing = L.LayerGroup.extend(
                  data: data,
                  //size: 8,
                  color: function(index, point) {
-                   // console.log(point); // point is currently just []
-                   return { r: 0.1, g: 0.1, b: 1 };
+                   var years;
+                   var preset_year = 2012;
+                   if (point.properties.years){
+                    years = point.properties.years.split(",").map(Number);
+                   }
+                   if (years && years.includes(preset_year)) {
+                    return { r: 0.1, g: 1.0, b: 0.1 }; 
+                   }
+                   else {
+                    return { r: 0.01, g: 0.01, b: 1.00 };
+                   }
                  },
                  sensitivity: 5,
                  click: function (e, point, xy) {


### PR DESCRIPTION
Fixes #288
I use gray to no longer operations sites, and green to operations sites
![Screen Shot 2019-12-11 at 16 34 01](https://user-images.githubusercontent.com/16153848/70653891-138b6100-1c34-11ea-8f11-85e83edf06be.png)
