### PR TITLE
Add display parameter to show specific layers

### DIFF
--- a/dist/LeafletEnvironmentalLayers.js
+++ b/dist/LeafletEnvironmentalLayers.js
@@ -25854,9 +25854,9 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
     options: {
       simpleLayerControl: false,
       hash: false,
-      embed: false, // activates layers on map by default if true.
+      embed: false,
       currentHash: location.hash,
-      addLayersToMap: false,
+      addLayersToMap: false, // activates layers on map by default if true.
       // Source of Truth of Layers name .
       // please put name of Layers carefully in the the appropriate layer group.
       layers0: ['PLpeople', 'purpleLayer', 'toxicReleaseLayer', 'pfasLayer', 'aqicnLayer', 'osmLandfillMineQuarryLayer', 'Unearthing'],
@@ -26062,13 +26062,16 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
         // Update map state from hash
         hash.update(this.options.currentHash);
       }
-        
-      for (let layer of this.options.layers.include) {
-        if (!this.options.addLayersToMap) {
-          return;
+
+      if (!!this.options.addLayersToMap) {  // turn on all layers
+        for (let layer of this.options.layers.include) {
+          map.addLayer(this.overlayMaps[layer]);
         }
-        map.addLayer(this.overlayMaps[layer]);
-      }
+      } else if (!!this.options.layers.display) {  // turn on only layers in display
+        for (let layer of this.options.layers.display) {
+          map.addLayer(this.overlayMaps[layer]);
+        }
+      } // or turn on nothing
       
     },
 

--- a/dist/LeafletEnvironmentalLayers.js
+++ b/dist/LeafletEnvironmentalLayers.js
@@ -26069,7 +26069,12 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
         }
       } else if (!!this.options.layers.display) {  // turn on only layers in display
         for (let layer of this.options.layers.display) {
-          map.addLayer(this.overlayMaps[layer]);
+          // make sure the layer exists in the display list
+          if (this.options.layers.include.includes(layer)) {
+            map.addLayer(this.overlayMaps[layer]);
+          } else {
+            console.log("Layer specified does not exist.");
+          }
         }
       } // or turn on nothing
       

--- a/example/oneLinerCodeExample.html
+++ b/example/oneLinerCodeExample.html
@@ -83,9 +83,9 @@
         // baseLayers: {
         //   'Standard': baselayer1
         // },
-        simpleLayerControl: true,
-        // addLayersToMap: false,
-        include: ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing', 'PLpeople'],
+        // simpleLayerControl: true,
+        addLayersToMap: true,
+        include: ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing'],
         // exclude: ['mapknitter', 'clouds'],
         hash: true,
         embed: true,

--- a/example/oneLinerCodeExample.html
+++ b/example/oneLinerCodeExample.html
@@ -84,10 +84,10 @@
         //   'Standard': baselayer1
         // },
         // simpleLayerControl: true,
-        addLayersToMap: true,
+        // addLayersToMap: true,
         include: ['purpleairmarker', 'skytruth', 'fractracker', 'odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing'],
         // exclude: ['mapknitter', 'clouds'],
-        // display: ['eonetFiresLayer'],
+        display: ['eonetFiresLayer'],
         // hash: true,
         embed: true,
         // hostname: 'domain name goes here'

--- a/example/oneLinerCodeExample.html
+++ b/example/oneLinerCodeExample.html
@@ -85,9 +85,10 @@
         // },
         // simpleLayerControl: true,
         addLayersToMap: true,
-        include: ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing'],
+        include: ['purpleairmarker', 'skytruth', 'fractracker', 'odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing'],
         // exclude: ['mapknitter', 'clouds'],
-        hash: true,
+        // display: ['eonetFiresLayer'],
+        // hash: true,
         embed: true,
         // hostname: 'domain name goes here'
       }).addTo(map);

--- a/src/AllLayers.js
+++ b/src/AllLayers.js
@@ -219,7 +219,12 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
         }
       } else if (!!this.options.layers.display) {  // turn on only layers in display
         for (let layer of this.options.layers.display) {
-          map.addLayer(this.overlayMaps[layer]);
+          // make sure the layer exists in the display list
+          if (this.options.layers.include.includes(layer)) {
+            map.addLayer(this.overlayMaps[layer]);
+          } else {
+            console.log("Layer specified does not exist.");
+          }
         }
       } // or turn on nothing
       

--- a/src/AllLayers.js
+++ b/src/AllLayers.js
@@ -212,13 +212,16 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
         // Update map state from hash
         hash.update(this.options.currentHash);
       }
-        
-      for (let layer of this.options.layers.include) {
-        if (!this.options.addLayersToMap) {
-          return;
+
+      if (!this.options.addLayersToMap) {  // turn on all layers
+        for (let layer of this.options.layers.include) {
+          map.addLayer(this.overlayMaps[layer]);
         }
-        map.addLayer(this.overlayMaps[layer]);
-      }
+      } else if (!!this.options.layers.display) {  // turn on only layers in display
+        for (let layer of this.options.layers.display) {
+          map.addLayer(this.overlayMaps[layer]);
+        }
+      } // or turn on nothing
       
     },
 

--- a/src/AllLayers.js
+++ b/src/AllLayers.js
@@ -4,9 +4,9 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
     options: {
       simpleLayerControl: false,
       hash: false,
-      embed: false, // activates layers on map by default if true.
+      embed: false,
       currentHash: location.hash,
-      addLayersToMap: false,
+      addLayersToMap: false, // activates layers on map by default if true.
       // Source of Truth of Layers name .
       // please put name of Layers carefully in the the appropriate layer group.
       layers0: ['PLpeople', 'purpleLayer', 'toxicReleaseLayer', 'pfasLayer', 'aqicnLayer', 'osmLandfillMineQuarryLayer', 'Unearthing'],
@@ -213,7 +213,7 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
         hash.update(this.options.currentHash);
       }
 
-      if (!this.options.addLayersToMap) {  // turn on all layers
+      if (!!this.options.addLayersToMap) {  // turn on all layers
         for (let layer of this.options.layers.include) {
           map.addLayer(this.overlayMaps[layer]);
         }


### PR DESCRIPTION
Fixes #377  (<=== Add issue number here)

There are cases in plots2 where we can't use a url hash to enable layers to be displayed. This param is optional and defaults to no layers being displayed on page load.
`include: ['layername']` will still limit what maps are available in the menu
`display: ['layername']` will turn on the specified layers, if they are available
`addLayersToMap: true` will override and display all layers that are available, regardless of what is in `display`

![Selection_041](https://user-images.githubusercontent.com/49460529/73560988-19c4df00-4426-11ea-86b1-d48c1d4f4dc3.png)
![FireShot Capture 268 - Leaflet Environmental Layers - ](https://user-images.githubusercontent.com/49460529/73560957-07e33c00-4426-11ea-9ca4-976115af23a7.png)


![Selection_042](https://user-images.githubusercontent.com/49460529/73560994-1d586600-4426-11ea-8c91-413c197f834f.png)
![FireShot Capture 269 - Leaflet Environmental Layers - ](https://user-images.githubusercontent.com/49460529/73560967-0ca7f000-4426-11ea-9f34-bc0520a8f31e.png)


![Selection_043](https://user-images.githubusercontent.com/49460529/73561016-20ebed00-4426-11ea-95a4-dda1670efd5c.png)
![FireShot Capture 270 - Leaflet Environmental Layers - ](https://user-images.githubusercontent.com/49460529/73560974-103b7700-4426-11ea-96c7-95f58650c614.png)


![Selection_045](https://user-images.githubusercontent.com/49460529/73561026-25180a80-4426-11ea-92f5-11f4b2407aef.png)
![Leaflet Environmental Layers - Google Chrome_044](https://user-images.githubusercontent.com/49460529/73561036-29dcbe80-4426-11ea-8874-b9c5fa0e5fd1.png)
