### PR TITLE
Reformat init defaults

### DIFF
--- a/_SpecRunner.html
+++ b/_SpecRunner.html
@@ -36,6 +36,8 @@
   
   <script src="src/util/embedControl.js"></script>
   
+  <script src="src/util/modeControl.js"></script>
+  
   <script src="dist/util/layersBrowser.js"></script>
   
   <script src="dist/fracTrackerMobileLayer.js"></script>
@@ -53,6 +55,8 @@
   <script src="spec/javascripts/layersBrowser.spec.js"></script>
   
   <script src="spec/javascripts/mapknitterLayer_spec.js"></script>
+  
+  <script src="spec/javascripts/modeControl.spec.js"></script>
   
   <script src="spec/javascripts/PLpeopleLayerTest_spec.js"></script>
   

--- a/dist/LeafletEnvironmentalLayers.js
+++ b/dist/LeafletEnvironmentalLayers.js
@@ -25852,11 +25852,13 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
 
   {
     options: {
-      simpleLayerControl: false,
-      hash: false,
-      embed: false,
+      default: {
+        simpleLayerControl: false,
+        hash: false,
+        embed: false,
+        addLayersToMap: false, // activates layers on map by default if true.
+      },
       currentHash: location.hash,
-      addLayersToMap: false, // activates layers on map by default if true.
       // Source of Truth of Layers name .
       // please put name of Layers carefully in the the appropriate layer group.
       layers0: ['PLpeople', 'purpleLayer', 'toxicReleaseLayer', 'pfasLayer', 'aqicnLayer', 'osmLandfillMineQuarryLayer', 'Unearthing'],
@@ -25887,15 +25889,14 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
 
     initialize: function(param) {
       param = param || {};
-      if (!!param.hash) {
-        this.options.hash = param.hash;
-      }
-      if (!!param.baseLayers) {
-        this.options.baseLayers = param.baseLayers;
-      }
-      if (!!param.include) {
-        this.options.addLayersToMap = param.addLayersToMap;
-      }
+
+      this.options.hash = param.hash || this.options.default.hash;
+      this.options.baseLayers = param.baseLayers || this.options.default.baseLayers;
+      this.options.addLayersToMap = param.addLayersToMap || this.options.default.addLayersToMap;
+      this.options.embed = param.embed || this.options.default.embed;
+      this.options.hostname = param.hostname || this.options.default.hostname;
+      this.options.simpleLayerControl = param.simpleLayerControl || this.options.default.simpleLayerControl;
+      
       param.all = [...this.options.layers0, ...this.options.layers1, ...this.options.layers2, ...this.options.layers3, ...this.options.layers4, ...this.options.layers5, ...this.options.layers6];
       if (!param.include || !param.include.length) {
         param.include = param.all;
@@ -25908,15 +25909,6 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
 
       this.options.layers = param;
 
-      if (!!param.embed) {
-        this.options.embed = param.embed;
-      }
-      if (!!param.hostname) {
-        this.options.hostname = param.hostname;
-      }
-      if (!!param.simpleLayerControl) {
-        this.options.simpleLayerControl = param.simpleLayerControl;
-      }
     },
 
     onAdd: function(map) {
@@ -26077,7 +26069,6 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
           }
         }
       } // or turn on nothing
-      
     },
 
     onRemove: function(map) {},

--- a/dist/LeafletEnvironmentalLayers.js
+++ b/dist/LeafletEnvironmentalLayers.js
@@ -25852,12 +25852,10 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
 
   {
     options: {
-      default: {
-        simpleLayerControl: false,
-        hash: false,
-        embed: false,
-        addLayersToMap: false, // activates layers on map by default if true.
-      },
+      simpleLayerControl: false,
+      hash: false,
+      embed: false,
+      addLayersToMap: false, // activates layers on map by default if true.
       currentHash: location.hash,
       // Source of Truth of Layers name .
       // please put name of Layers carefully in the the appropriate layer group.
@@ -25888,15 +25886,11 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
     },
 
     initialize: function(param) {
+      L.Util.setOptions(this, param);
       param = param || {};
 
-      this.options.hash = param.hash || this.options.default.hash;
-      this.options.baseLayers = param.baseLayers || this.options.default.baseLayers;
-      this.options.addLayersToMap = param.addLayersToMap || this.options.default.addLayersToMap;
-      this.options.embed = param.embed || this.options.default.embed;
-      this.options.hostname = param.hostname || this.options.default.hostname;
-      this.options.simpleLayerControl = param.simpleLayerControl || this.options.default.simpleLayerControl;
-      
+      this.options.addLayersToMap = !!param.include ? param.addLayersToMap : false;
+
       param.all = [...this.options.layers0, ...this.options.layers1, ...this.options.layers2, ...this.options.layers3, ...this.options.layers4, ...this.options.layers5, ...this.options.layers6];
       if (!param.include || !param.include.length) {
         param.include = param.all;

--- a/example/multipleMaps.html
+++ b/example/multipleMaps.html
@@ -77,13 +77,16 @@
 
       L.LayerGroup.EnvironmentalLayers({
         include: ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing', 'PLpeople'],
+        addLayersToMap: true,
+        simpleLayerControl: true,
       }).addTo(map);
+      console.log("done map 1");
 
       L.LayerGroup.EnvironmentalLayers({
-        simpleLayerControl: true,
-        addLayersToMap: true,
-        include: ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing', 'PLpeople'],
+        // include: ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing', 'PLpeople'],
+        display: ['odorreport', 'clouds', 'eonetFiresLayer', 'Unearthing'], 
       }).addTo(map2);
+      console.log("done map 2");
 
     </script>
     

--- a/example/multipleMaps.html
+++ b/example/multipleMaps.html
@@ -80,13 +80,11 @@
         addLayersToMap: true,
         simpleLayerControl: true,
       }).addTo(map);
-      console.log("done map 1");
 
       L.LayerGroup.EnvironmentalLayers({
         // include: ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing', 'PLpeople'],
         display: ['odorreport', 'clouds', 'eonetFiresLayer', 'Unearthing'], 
       }).addTo(map2);
-      console.log("done map 2");
 
     </script>
     

--- a/example/multipleMaps.html
+++ b/example/multipleMaps.html
@@ -83,7 +83,7 @@
 
       L.LayerGroup.EnvironmentalLayers({
         // include: ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing', 'PLpeople'],
-        display: ['odorreport', 'clouds', 'eonetFiresLayer', 'Unearthing'], 
+        // display: ['odorreport', 'clouds', 'eonetFiresLayer', 'Unearthing'], 
       }).addTo(map2);
 
     </script>

--- a/src/AllLayers.js
+++ b/src/AllLayers.js
@@ -2,12 +2,10 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
 
   {
     options: {
-      default: {
-        simpleLayerControl: false,
-        hash: false,
-        embed: false,
-        addLayersToMap: false, // activates layers on map by default if true.
-      },
+      simpleLayerControl: false,
+      hash: false,
+      embed: false,
+      addLayersToMap: false, // activates layers on map by default if true.
       currentHash: location.hash,
       // Source of Truth of Layers name .
       // please put name of Layers carefully in the the appropriate layer group.
@@ -38,15 +36,11 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
     },
 
     initialize: function(param) {
+      L.Util.setOptions(this, param);
       param = param || {};
 
-      this.options.hash = param.hash || this.options.default.hash;
-      this.options.baseLayers = param.baseLayers || this.options.default.baseLayers;
-      this.options.addLayersToMap = param.addLayersToMap || this.options.default.addLayersToMap;
-      this.options.embed = param.embed || this.options.default.embed;
-      this.options.hostname = param.hostname || this.options.default.hostname;
-      this.options.simpleLayerControl = param.simpleLayerControl || this.options.default.simpleLayerControl;
-      
+      this.options.addLayersToMap = !!param.include ? param.addLayersToMap : false;
+
       param.all = [...this.options.layers0, ...this.options.layers1, ...this.options.layers2, ...this.options.layers3, ...this.options.layers4, ...this.options.layers5, ...this.options.layers6];
       if (!param.include || !param.include.length) {
         param.include = param.all;

--- a/src/AllLayers.js
+++ b/src/AllLayers.js
@@ -2,11 +2,13 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
 
   {
     options: {
-      simpleLayerControl: false,
-      hash: false,
-      embed: false,
+      default: {
+        simpleLayerControl: false,
+        hash: false,
+        embed: false,
+        addLayersToMap: false, // activates layers on map by default if true.
+      },
       currentHash: location.hash,
-      addLayersToMap: false, // activates layers on map by default if true.
       // Source of Truth of Layers name .
       // please put name of Layers carefully in the the appropriate layer group.
       layers0: ['PLpeople', 'purpleLayer', 'toxicReleaseLayer', 'pfasLayer', 'aqicnLayer', 'osmLandfillMineQuarryLayer', 'Unearthing'],
@@ -37,15 +39,14 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
 
     initialize: function(param) {
       param = param || {};
-      if (!!param.hash) {
-        this.options.hash = param.hash;
-      }
-      if (!!param.baseLayers) {
-        this.options.baseLayers = param.baseLayers;
-      }
-      if (!!param.include) {
-        this.options.addLayersToMap = param.addLayersToMap;
-      }
+
+      this.options.hash = param.hash || this.options.default.hash;
+      this.options.baseLayers = param.baseLayers || this.options.default.baseLayers;
+      this.options.addLayersToMap = param.addLayersToMap || this.options.default.addLayersToMap;
+      this.options.embed = param.embed || this.options.default.embed;
+      this.options.hostname = param.hostname || this.options.default.hostname;
+      this.options.simpleLayerControl = param.simpleLayerControl || this.options.default.simpleLayerControl;
+      
       param.all = [...this.options.layers0, ...this.options.layers1, ...this.options.layers2, ...this.options.layers3, ...this.options.layers4, ...this.options.layers5, ...this.options.layers6];
       if (!param.include || !param.include.length) {
         param.include = param.all;
@@ -58,15 +59,6 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
 
       this.options.layers = param;
 
-      if (!!param.embed) {
-        this.options.embed = param.embed;
-      }
-      if (!!param.hostname) {
-        this.options.hostname = param.hostname;
-      }
-      if (!!param.simpleLayerControl) {
-        this.options.simpleLayerControl = param.simpleLayerControl;
-      }
     },
 
     onAdd: function(map) {
@@ -227,7 +219,6 @@ L.LayerGroup.environmentalLayers = L.LayerGroup.extend(
           }
         }
       } // or turn on nothing
-      
     },
 
     onRemove: function(map) {},


### PR DESCRIPTION
Fixes #395 (<=== Add issue number here)

This change should reset any subsequent maps to the correct default unless overriden by a new param.