### PR TITLE
make owmloading.gif configurable option

### DIFF
--- a/src/openWeatherMapLayer.js
+++ b/src/openWeatherMapLayer.js
@@ -223,7 +223,7 @@ L.OWM.Current = L.Layer.extend({
     minZoom: 7,
     interval: 0, // interval for rereading city data in minutes
     progressControl: true, // available: true, false
-    imageLoadingUrl: this.options.imageLoadingUrl || 'owmloading.gif', // URL of loading image relative to HTML document
+    imageLoadingUrl: 'owmloading.gif', // URL of loading image relative to HTML document
     imageLoadingBgUrl: null, // URL of background image for progress control
     temperatureUnit: 'C', // available: 'K' (Kelvin), 'C' (Celsius), 'F' (Fahrenheit)
     temperatureDigits: 1,
@@ -255,6 +255,7 @@ L.OWM.Current = L.Layer.extend({
   },
 
   initialize: function(options) {
+    options.imageLoadingUrl = this.options.imageLoadingUrl || "owmloading.gif";
     L.setOptions(this, options);
     this._layer = L.layerGroup();
     this._timeoutId = null;

--- a/src/openWeatherMapLayer.js
+++ b/src/openWeatherMapLayer.js
@@ -223,7 +223,7 @@ L.OWM.Current = L.Layer.extend({
     minZoom: 7,
     interval: 0, // interval for rereading city data in minutes
     progressControl: true, // available: true, false
-    imageLoadingUrl: 'owmloading.gif', // URL of loading image relative to HTML document
+    imageLoadingUrl: this.options.imageLoadingUrl || 'owmloading.gif', // URL of loading image relative to HTML document
     imageLoadingBgUrl: null, // URL of background image for progress control
     temperatureUnit: 'C', // available: 'K' (Kelvin), 'C' (Celsius), 'F' (Fahrenheit)
     temperatureDigits: 1,


### PR DESCRIPTION
Supercedes #473 

We should be able to set this when we initialize LEL here using:

```js
options.imageLoadingUrl = "someGifAnimation.gif"
```

For example in plots2, here:
 https://github.com/publiclab/plots2/blob/30fb69618430b589889f7e20cb8ce845e0b89e8d/app/assets/javascripts/leafletHelper.js#L116-L122