### PR TITLE
bump v2.4.9; indigenous lands layer fix for one-line constructor; commenting in AllLayers.js

### DIFF
--- a/cypress/integration/aqicn.spec.js
+++ b/cypress/integration/aqicn.spec.js
@@ -1,6 +1,6 @@
 describe('Aqicn layer', function() {
   it('adds markers on click', function() {
-    cy.openWindow('/example/index.html#40.4168&lon=-3.7029&zoom=16&layers=Standard')
+    cy.openWindow('/example/index.html#lat=51.15&lon=13.45&zoom=4&layers=Standard')
     cy.wait(300)
     cy.window().then((win) => {
       cy.fixture('aqicn').then((data) => {
@@ -10,12 +10,12 @@ describe('Aqicn layer', function() {
       })
 
       cy.get('#map-menu-aqicnLayer label').click({ force: true })
-      cy.get('.leaflet-marker-pane').children().should('have.length', 1)
+      cy.get('.leaflet-marker-pane').children().should('have.length', 2)
     }) 
   })
 
   it('should have the layer name added to the hash', function() {
-    cy.hash().should('eq', 'lat=40.4168&lon=-3.7029&zoom=16&layers=Standard,aqicnLayer')
+    cy.hash().should('eq', '#lat=51.15&lon=13.45&zoom=4&layers=Standard,aqicnLayer')
   })
 
   it('has default markers in default mode', function() {
@@ -39,12 +39,12 @@ describe('Aqicn layer', function() {
   it('shows popup', function() {
     cy.get('.leaflet-overlay-pane svg g').children().last().click({ force: true })
     cy.get('.leaflet-popup-pane').children().should('have.length', 1)
-    cy.get('.leaflet-popup-content').should('contain', 'Madrid')
+    cy.get('.leaflet-popup-content').should('contain', 'Spain')
   })
 
   it('removes markers from the map and the layer name from the hash when clicked again', function() {
     cy.get('#map-menu-aqicnLayer label').click({ force: true })
-    cy.hash().should('eq', '#lat=40.4168&lon=-3.7029&zoom=16&layers=Standard')
+    cy.hash().should('eq', '#lat=51.15&lon=13.45&zoom=4&layers=Standard')
     cy.get('.leaflet-marker-pane').children().should('have.length', 0)
     cy.get('.leaflet-overlay-pane svg g').children().should('have.length', 0)
   })

--- a/cypress/integration/aqicn.spec.js
+++ b/cypress/integration/aqicn.spec.js
@@ -1,6 +1,6 @@
 describe('Aqicn layer', function() {
   it('adds markers on click', function() {
-    cy.openWindow('/example/index.html#lat=51.15&lon=13.45&zoom=4&layers=Standard')
+    cy.openWindow('/example/index.html#40.4168&lon=-3.7029&zoom=16&layers=Standard')
     cy.wait(300)
     cy.window().then((win) => {
       cy.fixture('aqicn').then((data) => {
@@ -10,12 +10,12 @@ describe('Aqicn layer', function() {
       })
 
       cy.get('#map-menu-aqicnLayer label').click({ force: true })
-      cy.get('.leaflet-marker-pane').children().should('have.length', 2)
+      cy.get('.leaflet-marker-pane').children().should('have.length', 1)
     }) 
   })
 
   it('should have the layer name added to the hash', function() {
-    cy.hash().should('eq', '#lat=51.15&lon=13.45&zoom=4&layers=Standard,aqicnLayer')
+    cy.hash().should('eq', 'lat=40.4168&lon=-3.7029&zoom=16&layers=Standard,aqicnLayer')
   })
 
   it('has default markers in default mode', function() {
@@ -39,12 +39,12 @@ describe('Aqicn layer', function() {
   it('shows popup', function() {
     cy.get('.leaflet-overlay-pane svg g').children().last().click({ force: true })
     cy.get('.leaflet-popup-pane').children().should('have.length', 1)
-    cy.get('.leaflet-popup-content').should('contain', 'Spain')
+    cy.get('.leaflet-popup-content').should('contain', 'Madrid')
   })
 
   it('removes markers from the map and the layer name from the hash when clicked again', function() {
     cy.get('#map-menu-aqicnLayer label').click({ force: true })
-    cy.hash().should('eq', '#lat=51.15&lon=13.45&zoom=4&layers=Standard')
+    cy.hash().should('eq', '#lat=40.4168&lon=-3.7029&zoom=16&layers=Standard')
     cy.get('.leaflet-marker-pane').children().should('have.length', 0)
     cy.get('.leaflet-overlay-pane svg g').children().should('have.length', 0)
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leaflet-environmental-layers",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "leaflet-environmental-layers",
-      "version": "2.4.8",
+      "version": "2.4.9",
       "license": "ISC",
       "dependencies": {
         "esri-leaflet": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-environmental-layers",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Fixed indigenous lands layers in one-liner constructor

Some progress on labeling AllLayers.js - https://github.com/publiclab/leaflet-environmental-layers/issues/665

Also - going to merge despite test failures, which have developed as APIs have changed, as has the data they return.